### PR TITLE
Add CVSS v4 `DecisionTable` docs

### DIFF
--- a/docs/howto/cvss_v4/eq1.md
+++ b/docs/howto/cvss_v4/eq1.md
@@ -1,0 +1,66 @@
+# CVSS v4 Equivalence Set EQ1
+
+Here we describe an example decision model for an analyst assessing the CVSS v4
+equivalence set EQ1. 
+
+## Analyst Units of Work
+
+!!! info inline end "Analyst Unit of Work"
+
+    The unit of work for an Analyst is a single vulnerability report.
+
+Analysts are usually tasked with assessing the CVSS score for an individual
+vulnerability report. 
+
+## Analyst Decision Outcomes
+    
+The analyst's decision is to choose the appropriate level for CVSS v4 EQ1.
+
+```python exec="true" idprefix=""
+from ssvc.decision_tables.cvss.equivalence_set_one import LATEST as DT
+from ssvc.doc_helpers import example_block
+
+dp = DT.decision_points[DT.outcome]
+print(example_block(dp))
+```
+
+## Analyst Decision Points
+
+```python exec="true" idprefix=""
+from ssvc.decision_tables.cvss.equivalence_set_one import LATEST as DT
+from ssvc.doc_helpers import example_block
+
+for dp in [v for k,v in DT.decision_points.items() if k != DT.outcome]:
+    print(example_block(dp))
+```
+
+## Analyst Decision Model
+
+Below we provide an example deployer prioritization policy that maps the decision points just listed to the outcomes described above.
+
+### Decision Model Visualization
+
+The following diagram shows the decision model for the EQ1 decision.
+
+```python exec="true" idprefix=""
+from ssvc.decision_tables.cvss.equivalence_set_one import LATEST as DT
+from ssvc.decision_tables.helpers import mapping2mermaid, mermaid_title_from_dt
+
+rows = DT.mapping
+title = mermaid_title_from_dt(DT)
+print(mapping2mermaid(rows, title=title))
+```
+
+### Table of Values
+
+The table below shows the values for the decision model.
+Each row of the table corresponds to a path through the decision model diagram above.
+
+
+```python exec="true" idprefix=""
+
+from ssvc.decision_tables.cvss.equivalence_set_one import LATEST as DT
+from ssvc.decision_tables.helpers import dt2df_md
+
+print(dt2df_md(DT))
+```

--- a/docs/howto/cvss_v4/eq1.md
+++ b/docs/howto/cvss_v4/eq1.md
@@ -1,7 +1,7 @@
 # CVSS v4 Equivalence Set EQ1
 
 Here we describe an example decision model for an analyst assessing the CVSS v4
-equivalence set EQ1. 
+equivalence set EQ1.
 
 ## Analyst Units of Work
 
@@ -10,10 +10,10 @@ equivalence set EQ1.
     The unit of work for an Analyst is a single vulnerability report.
 
 Analysts are usually tasked with assessing the CVSS score for an individual
-vulnerability report. 
+vulnerability report.
 
 ## Analyst Decision Outcomes
-    
+
 The analyst's decision is to choose the appropriate level for CVSS v4 EQ1.
 
 ```python exec="true" idprefix=""
@@ -55,7 +55,6 @@ print(mapping2mermaid(rows, title=title))
 
 The table below shows the values for the decision model.
 Each row of the table corresponds to a path through the decision model diagram above.
-
 
 ```python exec="true" idprefix=""
 

--- a/docs/howto/cvss_v4/eq2.md
+++ b/docs/howto/cvss_v4/eq2.md
@@ -1,0 +1,66 @@
+# CVSS v4 Equivalence Set EQ2
+
+Here we describe an example decision model for an analyst assessing the CVSS v4
+equivalence set EQ2. 
+
+## Analyst Units of Work
+
+!!! info inline end "Analyst Unit of Work"
+
+    The unit of work for an Analyst is a single vulnerability report.
+
+Analysts are usually tasked with assessing the CVSS score for an individual
+vulnerability report. 
+
+## Analyst Decision Outcomes
+    
+The analyst's decision is to choose the appropriate level for CVSS v4 EQ2.
+
+```python exec="true" idprefix=""
+from ssvc.decision_tables.cvss.equivalence_set_two import LATEST as DT
+from ssvc.doc_helpers import example_block
+
+dp = DT.decision_points[DT.outcome]
+print(example_block(dp))
+```
+
+## Analyst Decision Points
+
+```python exec="true" idprefix=""
+from ssvc.decision_tables.cvss.equivalence_set_two import LATEST as DT
+from ssvc.doc_helpers import example_block
+
+for dp in [v for k,v in DT.decision_points.items() if k != DT.outcome]:
+    print(example_block(dp))
+```
+
+## Analyst Decision Model
+
+Below we provide an example deployer prioritization policy that maps the decision points just listed to the outcomes described above.
+
+### Decision Model Visualization
+
+The following diagram shows the decision model for the EQ2 decision.
+
+```python exec="true" idprefix=""
+from ssvc.decision_tables.cvss.equivalence_set_two import LATEST as DT
+from ssvc.decision_tables.helpers import mapping2mermaid, mermaid_title_from_dt
+
+rows = DT.mapping
+title = mermaid_title_from_dt(DT)
+print(mapping2mermaid(rows, title=title))
+```
+
+### Table of Values
+
+The table below shows the values for the decision model.
+Each row of the table corresponds to a path through the decision model diagram above.
+
+
+```python exec="true" idprefix=""
+
+from ssvc.decision_tables.cvss.equivalence_set_two import LATEST as DT
+from ssvc.decision_tables.helpers import dt2df_md
+
+print(dt2df_md(DT))
+```

--- a/docs/howto/cvss_v4/eq2.md
+++ b/docs/howto/cvss_v4/eq2.md
@@ -1,7 +1,7 @@
 # CVSS v4 Equivalence Set EQ2
 
 Here we describe an example decision model for an analyst assessing the CVSS v4
-equivalence set EQ2. 
+equivalence set EQ2.
 
 ## Analyst Units of Work
 
@@ -10,10 +10,10 @@ equivalence set EQ2.
     The unit of work for an Analyst is a single vulnerability report.
 
 Analysts are usually tasked with assessing the CVSS score for an individual
-vulnerability report. 
+vulnerability report.
 
 ## Analyst Decision Outcomes
-    
+
 The analyst's decision is to choose the appropriate level for CVSS v4 EQ2.
 
 ```python exec="true" idprefix=""
@@ -55,7 +55,6 @@ print(mapping2mermaid(rows, title=title))
 
 The table below shows the values for the decision model.
 Each row of the table corresponds to a path through the decision model diagram above.
-
 
 ```python exec="true" idprefix=""
 

--- a/docs/howto/cvss_v4/eq3.md
+++ b/docs/howto/cvss_v4/eq3.md
@@ -1,7 +1,7 @@
 # CVSS v4 Equivalence Set EQ3
 
 Here we describe an example decision model for an analyst assessing the CVSS v4
-equivalence set EQ3. 
+equivalence set EQ3.
 
 ## Analyst Units of Work
 
@@ -10,10 +10,10 @@ equivalence set EQ3.
     The unit of work for an Analyst is a single vulnerability report.
 
 Analysts are usually tasked with assessing the CVSS score for an individual
-vulnerability report. 
+vulnerability report.
 
 ## Analyst Decision Outcomes
-    
+
 The analyst's decision is to choose the appropriate level for CVSS v4 EQ3.
 
 ```python exec="true" idprefix=""
@@ -55,7 +55,6 @@ print(mapping2mermaid(rows, title=title))
 
 The table below shows the values for the decision model.
 Each row of the table corresponds to a path through the decision model diagram above.
-
 
 ```python exec="true" idprefix=""
 

--- a/docs/howto/cvss_v4/eq3.md
+++ b/docs/howto/cvss_v4/eq3.md
@@ -1,0 +1,66 @@
+# CVSS v4 Equivalence Set EQ3
+
+Here we describe an example decision model for an analyst assessing the CVSS v4
+equivalence set EQ3. 
+
+## Analyst Units of Work
+
+!!! info inline end "Analyst Unit of Work"
+
+    The unit of work for an Analyst is a single vulnerability report.
+
+Analysts are usually tasked with assessing the CVSS score for an individual
+vulnerability report. 
+
+## Analyst Decision Outcomes
+    
+The analyst's decision is to choose the appropriate level for CVSS v4 EQ3.
+
+```python exec="true" idprefix=""
+from ssvc.decision_tables.cvss.equivalence_set_three import LATEST as DT
+from ssvc.doc_helpers import example_block
+
+dp = DT.decision_points[DT.outcome]
+print(example_block(dp))
+```
+
+## Analyst Decision Points
+
+```python exec="true" idprefix=""
+from ssvc.decision_tables.cvss.equivalence_set_three import LATEST as DT
+from ssvc.doc_helpers import example_block
+
+for dp in [v for k,v in DT.decision_points.items() if k != DT.outcome]:
+    print(example_block(dp))
+```
+
+## Analyst Decision Model
+
+Below we provide an example deployer prioritization policy that maps the decision points just listed to the outcomes described above.
+
+### Decision Model Visualization
+
+The following diagram shows the decision model for the EQ3 decision.
+
+```python exec="true" idprefix=""
+from ssvc.decision_tables.cvss.equivalence_set_three import LATEST as DT
+from ssvc.decision_tables.helpers import mapping2mermaid, mermaid_title_from_dt
+
+rows = DT.mapping
+title = mermaid_title_from_dt(DT)
+print(mapping2mermaid(rows, title=title))
+```
+
+### Table of Values
+
+The table below shows the values for the decision model.
+Each row of the table corresponds to a path through the decision model diagram above.
+
+
+```python exec="true" idprefix=""
+
+from ssvc.decision_tables.cvss.equivalence_set_three import LATEST as DT
+from ssvc.decision_tables.helpers import dt2df_md
+
+print(dt2df_md(DT))
+```

--- a/docs/howto/cvss_v4/eq4.md
+++ b/docs/howto/cvss_v4/eq4.md
@@ -1,0 +1,66 @@
+# CVSS v4 Equivalence Set EQ4
+
+Here we describe an example decision model for an analyst assessing the CVSS v4
+equivalence set EQ4. 
+
+## Analyst Units of Work
+
+!!! info inline end "Analyst Unit of Work"
+
+    The unit of work for an Analyst is a single vulnerability report.
+
+Analysts are usually tasked with assessing the CVSS score for an individual
+vulnerability report. 
+
+## Analyst Decision Outcomes
+    
+The analyst's decision is to choose the appropriate level for CVSS v4 EQ4.
+
+```python exec="true" idprefix=""
+from ssvc.decision_tables.cvss.equivalence_set_four import LATEST as DT
+from ssvc.doc_helpers import example_block
+
+dp = DT.decision_points[DT.outcome]
+print(example_block(dp))
+```
+
+## Analyst Decision Points
+
+```python exec="true" idprefix=""
+from ssvc.decision_tables.cvss.equivalence_set_four import LATEST as DT
+from ssvc.doc_helpers import example_block
+
+for dp in [v for k,v in DT.decision_points.items() if k != DT.outcome]:
+    print(example_block(dp))
+```
+
+## Analyst Decision Model
+
+Below we provide an example deployer prioritization policy that maps the decision points just listed to the outcomes described above.
+
+### Decision Model Visualization
+
+The following diagram shows the decision model for the EQ4 decision.
+
+```python exec="true" idprefix=""
+from ssvc.decision_tables.cvss.equivalence_set_four import LATEST as DT
+from ssvc.decision_tables.helpers import mapping2mermaid, mermaid_title_from_dt
+
+rows = DT.mapping
+title = mermaid_title_from_dt(DT)
+print(mapping2mermaid(rows, title=title))
+```
+
+### Table of Values
+
+The table below shows the values for the decision model.
+Each row of the table corresponds to a path through the decision model diagram above.
+
+
+```python exec="true" idprefix=""
+
+from ssvc.decision_tables.cvss.equivalence_set_four import LATEST as DT
+from ssvc.decision_tables.helpers import dt2df_md
+
+print(dt2df_md(DT))
+```

--- a/docs/howto/cvss_v4/eq4.md
+++ b/docs/howto/cvss_v4/eq4.md
@@ -1,7 +1,7 @@
 # CVSS v4 Equivalence Set EQ4
 
 Here we describe an example decision model for an analyst assessing the CVSS v4
-equivalence set EQ4. 
+equivalence set EQ4.
 
 ## Analyst Units of Work
 
@@ -10,10 +10,10 @@ equivalence set EQ4.
     The unit of work for an Analyst is a single vulnerability report.
 
 Analysts are usually tasked with assessing the CVSS score for an individual
-vulnerability report. 
+vulnerability report.
 
 ## Analyst Decision Outcomes
-    
+
 The analyst's decision is to choose the appropriate level for CVSS v4 EQ4.
 
 ```python exec="true" idprefix=""
@@ -55,7 +55,6 @@ print(mapping2mermaid(rows, title=title))
 
 The table below shows the values for the decision model.
 Each row of the table corresponds to a path through the decision model diagram above.
-
 
 ```python exec="true" idprefix=""
 

--- a/docs/howto/cvss_v4/eq5.md
+++ b/docs/howto/cvss_v4/eq5.md
@@ -1,7 +1,7 @@
 # CVSS v4 Equivalence Set EQ5
 
 Here we describe an example decision model for an analyst assessing the CVSS v4
-equivalence set EQ5. 
+equivalence set EQ5.
 
 ## Analyst Units of Work
 
@@ -10,10 +10,10 @@ equivalence set EQ5.
     The unit of work for an Analyst is a single vulnerability report.
 
 Analysts are usually tasked with assessing the CVSS score for an individual
-vulnerability report. 
+vulnerability report.
 
 ## Analyst Decision Outcomes
-    
+
 The analyst's decision is to choose the appropriate level for CVSS v4 EQ5.
 
 ```python exec="true" idprefix=""
@@ -55,7 +55,6 @@ print(mapping2mermaid(rows, title=title))
 
 The table below shows the values for the decision model.
 Each row of the table corresponds to a path through the decision model diagram above.
-
 
 ```python exec="true" idprefix=""
 

--- a/docs/howto/cvss_v4/eq5.md
+++ b/docs/howto/cvss_v4/eq5.md
@@ -1,0 +1,66 @@
+# CVSS v4 Equivalence Set EQ5
+
+Here we describe an example decision model for an analyst assessing the CVSS v4
+equivalence set EQ5. 
+
+## Analyst Units of Work
+
+!!! info inline end "Analyst Unit of Work"
+
+    The unit of work for an Analyst is a single vulnerability report.
+
+Analysts are usually tasked with assessing the CVSS score for an individual
+vulnerability report. 
+
+## Analyst Decision Outcomes
+    
+The analyst's decision is to choose the appropriate level for CVSS v4 EQ5.
+
+```python exec="true" idprefix=""
+from ssvc.decision_tables.cvss.equivalence_set_five import LATEST as DT
+from ssvc.doc_helpers import example_block
+
+dp = DT.decision_points[DT.outcome]
+print(example_block(dp))
+```
+
+## Analyst Decision Points
+
+```python exec="true" idprefix=""
+from ssvc.decision_tables.cvss.equivalence_set_five import LATEST as DT
+from ssvc.doc_helpers import example_block
+
+for dp in [v for k,v in DT.decision_points.items() if k != DT.outcome]:
+    print(example_block(dp))
+```
+
+## Analyst Decision Model
+
+Below we provide an example deployer prioritization policy that maps the decision points just listed to the outcomes described above.
+
+### Decision Model Visualization
+
+The following diagram shows the decision model for the EQ5 decision.
+
+```python exec="true" idprefix=""
+from ssvc.decision_tables.cvss.equivalence_set_five import LATEST as DT
+from ssvc.decision_tables.helpers import mapping2mermaid, mermaid_title_from_dt
+
+rows = DT.mapping
+title = mermaid_title_from_dt(DT)
+print(mapping2mermaid(rows, title=title))
+```
+
+### Table of Values
+
+The table below shows the values for the decision model.
+Each row of the table corresponds to a path through the decision model diagram above.
+
+
+```python exec="true" idprefix=""
+
+from ssvc.decision_tables.cvss.equivalence_set_five import LATEST as DT
+from ssvc.decision_tables.helpers import dt2df_md
+
+print(dt2df_md(DT))
+```

--- a/docs/howto/cvss_v4/eq6.md
+++ b/docs/howto/cvss_v4/eq6.md
@@ -1,0 +1,66 @@
+# CVSS v4 Equivalence Set EQ6
+
+Here we describe an example decision model for an analyst assessing the CVSS v4
+equivalence set EQ6. 
+
+## Analyst Units of Work
+
+!!! info inline end "Analyst Unit of Work"
+
+    The unit of work for an Analyst is a single vulnerability report.
+
+Analysts are usually tasked with assessing the CVSS score for an individual
+vulnerability report. 
+
+## Analyst Decision Outcomes
+    
+The analyst's decision is to choose the appropriate level for CVSS v4 EQ6.
+
+```python exec="true" idprefix=""
+from ssvc.decision_tables.cvss.equivalence_set_six import LATEST as DT
+from ssvc.doc_helpers import example_block
+
+dp = DT.decision_points[DT.outcome]
+print(example_block(dp))
+```
+
+## Analyst Decision Points
+
+```python exec="true" idprefix=""
+from ssvc.decision_tables.cvss.equivalence_set_six import LATEST as DT
+from ssvc.doc_helpers import example_block
+
+for dp in [v for k,v in DT.decision_points.items() if k != DT.outcome]:
+    print(example_block(dp))
+```
+
+## Analyst Decision Model
+
+Below we provide an example deployer prioritization policy that maps the decision points just listed to the outcomes described above.
+
+### Decision Model Visualization
+
+The following diagram shows the decision model for the EQ6 decision.
+
+```python exec="true" idprefix=""
+from ssvc.decision_tables.cvss.equivalence_set_six import LATEST as DT
+from ssvc.decision_tables.helpers import mapping2mermaid, mermaid_title_from_dt
+
+rows = DT.mapping
+title = mermaid_title_from_dt(DT)
+print(mapping2mermaid(rows, title=title))
+```
+
+### Table of Values
+
+The table below shows the values for the decision model.
+Each row of the table corresponds to a path through the decision model diagram above.
+
+
+```python exec="true" idprefix=""
+
+from ssvc.decision_tables.cvss.equivalence_set_six import LATEST as DT
+from ssvc.decision_tables.helpers import dt2df_md
+
+print(dt2df_md(DT))
+```

--- a/docs/howto/cvss_v4/eq6.md
+++ b/docs/howto/cvss_v4/eq6.md
@@ -1,7 +1,7 @@
 # CVSS v4 Equivalence Set EQ6
 
 Here we describe an example decision model for an analyst assessing the CVSS v4
-equivalence set EQ6. 
+equivalence set EQ6.
 
 ## Analyst Units of Work
 
@@ -10,10 +10,10 @@ equivalence set EQ6.
     The unit of work for an Analyst is a single vulnerability report.
 
 Analysts are usually tasked with assessing the CVSS score for an individual
-vulnerability report. 
+vulnerability report.
 
 ## Analyst Decision Outcomes
-    
+
 The analyst's decision is to choose the appropriate level for CVSS v4 EQ6.
 
 ```python exec="true" idprefix=""
@@ -55,7 +55,6 @@ print(mapping2mermaid(rows, title=title))
 
 The table below shows the values for the decision model.
 Each row of the table corresponds to a path through the decision model diagram above.
-
 
 ```python exec="true" idprefix=""
 

--- a/docs/howto/cvss_v4/index.md
+++ b/docs/howto/cvss_v4/index.md
@@ -1,8 +1,8 @@
 # CVSS v4 Assessment With SSVC
 
 [CVSS v4](https://www.first.org/cvss/v4-0/specification-document) introduces an
-updated scoring system that includes several metric groupings referred to 
-as _Equivalence Sets_. 
+updated scoring system that includes several metric groupings referred to
+as *Equivalence Sets*.
 In SSVC, we can model these individual equivalence sets as decision tables
 that can be used by analysts to assess each equivalence set value based on
 its component metrics (which we have mapped into SSVC decision points).
@@ -26,7 +26,6 @@ by another source.
     create a broader set of decision models that incorporate CVSS vector
     elements as inputs.
 
-
 ## CVSS v4 Equivalence Sets
 
 Here we provide the decision points for each of the CVSS v4 equivalence sets.
@@ -48,10 +47,9 @@ We provide a detailed decision table for each equivalence set in the pages that 
 - [CVSS v4 Equivalence Set EQ5](eq5.md)
 - [CVSS v4 Equivalence Set EQ6](eq6.md)
 
-
 ## CVSS v4 Qualitative Severity Rating
 
-Finally, CVSS v4 provides a _Qualitative Severity Rating_ that maps the six equivalence
+Finally, CVSS v4 provides a *Qualitative Severity Rating* that maps the six equivalence
 sets into a single qualitative rating (None, Low, Medium, High, Critical).
 
 ```python exec="true" idprefix=""
@@ -64,7 +62,7 @@ print(example_block(dp))
 A full decision model for the CVSS v4 Qualitative Severity Rating can be found
 in the [CVSS v4 Qualitative Severity Rating](qualitative.md) page.
 
-!!! question "What about CVSS v4 _MacroVectors_?"
+!!! question "What about CVSS v4 *MacroVectors*?"
 
     CVSS v4 _MacroVectors_ are a new addition in CVSS v4 that provide a way to
     map the six equivalence sets into a single vector value that can be used
@@ -72,7 +70,6 @@ in the [CVSS v4 Qualitative Severity Rating](qualitative.md) page.
     In our implementation here, we simply model the MacroVector as another decision
     table that takes the individual equivalence set outcomes as inputs and provides
     the Qualitative Severity Rating as its outcome.
-
 
 !!! question "How are CVSS v4 scores handled?"
 

--- a/docs/howto/cvss_v4/index.md
+++ b/docs/howto/cvss_v4/index.md
@@ -1,0 +1,108 @@
+# CVSS v4 Assessment With SSVC
+
+[CVSS v4](https://www.first.org/cvss/v4-0/specification-document) introduces an
+updated scoring system that includes several metric groupings referred to 
+as _Equivalence Sets_. 
+In SSVC, we can model these individual equivalence sets as decision tables
+that can be used by analysts to assess each equivalence set value based on
+its component metrics (which we have mapped into SSVC decision points).
+
+An Analyst can use these decision tables to assess the CVSS v4 equivalence set
+values based either on their own assessments or by using a CVSS v4 vector published
+by another source.
+
+!!! question "I thought SSVC and CVSS were different?"
+
+    SSVC and CVSS are indeed different, but they can be used together.
+    We do not see SSVC as a replacement for CVSS, but rather as a complementary
+    decision-making framework that can help stakeholders make a variety of 
+    vulnerability response decisions.
+    In fact, we're very interested in using CVSS vector elements as inputs to 
+    SSVC decision tables to help stakeholders make more informed prioritization
+    decisions that leverage the community's understanding of a vulnerability's
+    characteristics and impact assessments.
+    In the future, we hope to see more SSVC decision tables that are
+    directly informed by CVSS vectors, allowing analysts to use SSVC to
+    create a broader set of decision models that incorporate CVSS vector
+    elements as inputs.
+
+
+## CVSS v4 Equivalence Sets
+
+Here we provide the decision points for each of the CVSS v4 equivalence sets.
+
+```python exec="true" idprefix=""
+from ssvc.decision_tables.cvss.qualitative_severity import LATEST as DT
+from ssvc.doc_helpers import example_block
+
+for dp in [v for k,v in DT.decision_points.items() if k != DT.outcome]:
+    print(example_block(dp))
+```
+
+We provide a detailed decision table for each equivalence set in the pages that follow:
+
+- [CVSS v4 Equivalence Set EQ1](eq1.md)
+- [CVSS v4 Equivalence Set EQ2](eq2.md)
+- [CVSS v4 Equivalence Set EQ3](eq3.md)
+- [CVSS v4 Equivalence Set EQ4](eq4.md)
+- [CVSS v4 Equivalence Set EQ5](eq5.md)
+- [CVSS v4 Equivalence Set EQ6](eq6.md)
+
+
+## CVSS v4 Qualitative Severity Rating
+
+Finally, CVSS v4 provides a _Qualitative Severity Rating_ that maps the six equivalence
+sets into a single qualitative rating (None, Low, Medium, High, Critical).
+
+```python exec="true" idprefix=""
+from ssvc.decision_tables.cvss.qualitative_severity import LATEST as DT
+from ssvc.doc_helpers import example_block
+dp = DT.decision_points[DT.outcome]
+print(example_block(dp))
+```
+
+A full decision model for the CVSS v4 Qualitative Severity Rating can be found
+in the [CVSS v4 Qualitative Severity Rating](qualitative.md) page.
+
+!!! question "What about CVSS v4 _MacroVectors_?"
+
+    CVSS v4 _MacroVectors_ are a new addition in CVSS v4 that provide a way to
+    map the six equivalence sets into a single vector value that can be used
+    to assign a CVSS v4 base score.
+    In our implementation here, we simply model the MacroVector as another decision
+    table that takes the individual equivalence set outcomes as inputs and provides
+    the Qualitative Severity Rating as its outcome.
+
+
+!!! question "How are CVSS v4 scores handled?"
+
+    We do not provide numerical CVSS v4 scores in this implementation. 
+    The CVSS v4 specification defines a 
+    [lookup table](https://github.com/FIRSTdotorg/cvss-v4-calculator/blob/main/cvss_lookup.js) 
+    and a complex algorithm to compute a score between 0.0 and 10.0 based on 
+    equivalence set values and the CVSS v4 vector.
+
+    In practice, many analysts convert numerical scores into qualitative 
+    severity ratings, such as None, Low, Medium, High, or Critical:
+
+    | Numerical Score | Qualitative Severity Rating |
+    |-----------------|----------------------------|
+    | 0.0             | None                       |
+    | 0.1 - 3.9       | Low                        |
+    | 4.0 - 6.9       | Medium                     |
+    | 7.0 - 8.9       | High                       |
+    | 9.0 - 10.0      | Critical                   |
+
+    One of our [original concerns](https://doi.ieeecomputersociety.org/10.1109/MSEC.2020.3044475) 
+    about CVSS v3—and still relevant in CVSS v4—was that numerical scores were 
+    often misused or misinterpreted, leading to poor prioritization decisions. 
+    To avoid this, we focus on mapping equivalence set values directly to 
+    qualitative severity ratings, which is the outcome many organizations actually 
+    care about.
+
+    Using SSVC, we can model the same assessment process that an analyst would 
+    use with CVSS v4, but entirely bypass the numerical score. 
+    The logic is identical: given a set of equivalence values, SSVC produces the
+    same qualitative severity rating as the [CVSS v4 Calculator](https://www.first.org/cvss/calculator/4-0).
+    This demonstrates that numerical scores are not 
+    necessary for effective prioritization or decision-making.

--- a/docs/howto/cvss_v4/qualitative.md
+++ b/docs/howto/cvss_v4/qualitative.md
@@ -1,8 +1,8 @@
 # CVSS v4  Qualitative Severity Rating
 
 Here we describe an example decision model for an analyst assessing the CVSS v4
-Qualitative Severity Rating. 
-In our decision model, we assume that the analyst has already assessed the 
+Qualitative Severity Rating.
+In our decision model, we assume that the analyst has already assessed the
 vulnerability report against the CVSS v4 Equivalence Sets:
 
 - EQ1: [CVSS v4 Equivalence Set 1](eq1.md)
@@ -12,7 +12,7 @@ vulnerability report against the CVSS v4 Equivalence Sets:
 - EQ5: [CVSS v4 Equivalence Set 5](eq5.md)
 - EQ6: [CVSS v4 Equivalence Set 6](eq6.md)
 
-and is now ready to assign a qualitative severity rating based on the outcomes 
+and is now ready to assign a qualitative severity rating based on the outcomes
 of those equivalence sets.
 
 !!! info "How we modeled the CVSS v4 Qualitative Severity Rating"
@@ -42,10 +42,10 @@ of those equivalence sets.
     The unit of work for an Analyst is a single vulnerability report.
 
 Analysts are usually tasked with assessing the CVSS score for an individual
-vulnerability report. 
+vulnerability report.
 
 ## Analyst Decision Outcomes
-    
+
 The analyst's decision is to choose the appropriate level for the CVSS v4 Qualitative Severity Rating.
 
 ```python exec="true" idprefix=""
@@ -94,12 +94,10 @@ rows = [row for row in rows if not invalid(row)]
 print(mapping2mermaid(rows, title=title))
 ```
 
-
 ### Table of Values
 
 The table below shows the values for the decision model.
 Each row of the table corresponds to a path through the decision model diagram above.
-
 
 ```python exec="true" idprefix=""
 

--- a/docs/howto/cvss_v4/qualitative.md
+++ b/docs/howto/cvss_v4/qualitative.md
@@ -83,8 +83,17 @@ from ssvc.decision_tables.helpers import mapping2mermaid, mermaid_title_from_dt
 
 rows = DT.mapping
 title = mermaid_title_from_dt(DT)
+
+# filter rows for invalid
+def invalid(row):
+    if row["cvss:EQ3:1.0.0"] == "L" and row["cvss:EQ6:1.0.0"] == "H":
+        return True
+    return False
+
+rows = [row for row in rows if not invalid(row)]
 print(mapping2mermaid(rows, title=title))
 ```
+
 
 ### Table of Values
 
@@ -96,6 +105,15 @@ Each row of the table corresponds to a path through the decision model diagram a
 
 from ssvc.decision_tables.cvss.qualitative_severity import LATEST as DT
 from ssvc.decision_tables.helpers import dt2df_md
+
+# filter rows for invalid (these don't affect the outcome because they're
+# unreachable from valid CVSS vectors)
+def invalid(row):
+    if row["cvss:EQ3:1.0.0"] == "L" and row["cvss:EQ6:1.0.0"] == "H":
+        return True
+    return False
+
+DT.mapping = [row for row in DT.mapping if not invalid(row)]
 
 print(dt2df_md(DT))
 ```

--- a/docs/howto/cvss_v4/qualitative.md
+++ b/docs/howto/cvss_v4/qualitative.md
@@ -1,0 +1,101 @@
+# CVSS v4  Qualitative Severity Rating
+
+Here we describe an example decision model for an analyst assessing the CVSS v4
+Qualitative Severity Rating. 
+In our decision model, we assume that the analyst has already assessed the 
+vulnerability report against the CVSS v4 Equivalence Sets:
+
+- EQ1: [CVSS v4 Equivalence Set 1](eq1.md)
+- EQ2: [CVSS v4 Equivalence Set 2](eq2.md)
+- EQ3: [CVSS v4 Equivalence Set 3](eq3.md)
+- EQ4: [CVSS v4 Equivalence Set 4](eq4.md)
+- EQ5: [CVSS v4 Equivalence Set 5](eq5.md)
+- EQ6: [CVSS v4 Equivalence Set 6](eq6.md)
+
+and is now ready to assign a qualitative severity rating based on the outcomes 
+of those equivalence sets.
+
+!!! info "How we modeled the CVSS v4 Qualitative Severity Rating"
+
+    The CVSS v4 specification provides a 
+    [mapping](https://github.com/FIRSTdotorg/cvss-v4-calculator/blob/main/cvss_lookup.js)
+    from each CVSS v4 *MacroVector* (made up of the six equivalence set selections)
+    to a numerical score between 0.0 and 10.0.
+    CVSS has traditionally provided the following mapping from numerical score
+    ranges to qualitative severity ratings:
+
+    | Numerical Score | Qualitative Severity Rating |
+    |------------------|-----------------------------|
+    | 0.0              | None                        |
+    | 0.1 - 3.9        | Low                         |
+    | 4.0 - 6.9        | Medium                      |
+    | 7.0 - 8.9        | High                        |
+
+    In our implementation, we just skip the numerical score step and go directly
+    from the equivalence set outcomes to the qualitative severity rating that
+    corresponds to the numerical score in the lookup table linked above.
+
+## Analyst Units of Work
+
+!!! info inline end "Analyst Unit of Work"
+
+    The unit of work for an Analyst is a single vulnerability report.
+
+Analysts are usually tasked with assessing the CVSS score for an individual
+vulnerability report. 
+
+## Analyst Decision Outcomes
+    
+The analyst's decision is to choose the appropriate level for the CVSS v4 Qualitative Severity Rating.
+
+```python exec="true" idprefix=""
+from ssvc.decision_tables.cvss.qualitative_severity import LATEST as DT
+from ssvc.doc_helpers import example_block
+
+dp = DT.decision_points[DT.outcome]
+print(example_block(dp))
+```
+
+## Analyst Decision Points
+
+Each of these decision points corresponds to the outcome of one of the six equivalence set
+decision tables.
+
+```python exec="true" idprefix=""
+from ssvc.decision_tables.cvss.qualitative_severity import LATEST as DT
+from ssvc.doc_helpers import example_block
+
+for dp in [v for k,v in DT.decision_points.items() if k != DT.outcome]:
+    print(example_block(dp))
+```
+
+## Analyst Decision Model
+
+Below we provide an example deployer prioritization policy that maps the decision points just listed to the outcomes described above.
+
+### Decision Model Visualization
+
+The following diagram shows the decision model for the Qualitative Severity Rating decision.
+
+```python exec="true" idprefix=""
+from ssvc.decision_tables.cvss.qualitative_severity import LATEST as DT
+from ssvc.decision_tables.helpers import mapping2mermaid, mermaid_title_from_dt
+
+rows = DT.mapping
+title = mermaid_title_from_dt(DT)
+print(mapping2mermaid(rows, title=title))
+```
+
+### Table of Values
+
+The table below shows the values for the decision model.
+Each row of the table corresponds to a path through the decision model diagram above.
+
+
+```python exec="true" idprefix=""
+
+from ssvc.decision_tables.cvss.qualitative_severity import LATEST as DT
+from ssvc.decision_tables.helpers import dt2df_md
+
+print(dt2df_md(DT))
+```

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -21,6 +21,15 @@ nav:
           - About Coordination: 'howto/coordination_intro.md'
           - Coordination Triage: 'howto/coordination_triage_decision.md'
           - Publication Decision: 'howto/publication_decision.md'
+        - CVSS v4 Analyst Models:
+            - About CVSS v4: 'howto/cvss_v4/index.md'
+            - Equivalence Set 1: 'howto/cvss_v4/eq1.md'
+            - Equivalence Set 2: 'howto/cvss_v4/eq2.md'
+            - Equivalence Set 3: 'howto/cvss_v4/eq3.md'
+            - Equivalence Set 4: 'howto/cvss_v4/eq4.md'
+            - Equivalence Set 5: 'howto/cvss_v4/eq5.md'
+            - Equivalence Set 6: 'howto/cvss_v4/eq6.md'
+            - Qualitative Severity: 'howto/cvss_v4/qualitative.md'
     - Customizing SSVC: 'howto/tree_customization.md'
     - Acuity Ramp: 'howto/acuity_ramp.md'
   - Understanding SSVC:

--- a/src/ssvc/decision_tables/cvss/qualitative_severity.py
+++ b/src/ssvc/decision_tables/cvss/qualitative_severity.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 """
-Models the CVSS v4.0 Qualitative Severity Ratings from Equivalency Set 1-6
+Models the CVSS v4.0 Qualitative Severity Ratings from Equivalence Set 1-6
 """
 #  Copyright (c) 2025 Carnegie Mellon University.
 #  NO WARRANTY. THIS CARNEGIE MELLON UNIVERSITY AND SOFTWARE

--- a/src/test/decision_tables/cvss/_v4expected.py
+++ b/src/test/decision_tables/cvss/_v4expected.py
@@ -1,6 +1,6 @@
 """
 This test helper module provides a complete set of expected values for the CVSS v4 Qualitative Severity Rating Scale (QSR)
-mapped to the CVSS v4 Equivalency Set combinations.
+mapped to the CVSS v4 Equivalence Set combinations.
 
 It was generated based on https://github.com/FIRSTdotorg/cvss-v4-calculator/blob/main/cvss_lookup.js
 """


### PR DESCRIPTION
- resolves CERTCC/SSVC#880

This PR extends
- #884

and adds documentation pages for the six CVSS v4 EQ set `DecisionTable` objects added in
- #863 
- #871 

## Copilot Summary

This pull request adds comprehensive documentation and navigation support for modeling CVSS v4 assessment using SSVC decision tables. It introduces new pages for each CVSS v4 equivalence set, a summary page explaining the approach, and a page for the qualitative severity rating, as well as updates navigation and minor terminology corrections.

Documentation additions:

* Added detailed documentation pages for each CVSS v4 equivalence set (`eq1.md` through `eq6.md`), providing analyst decision models, visualizations, and value tables for each set. [[1]](diffhunk://#diff-1a2581276af5b77d4ffe8371dfcc044fe98a7122ea6c3e57284561c8b2a87c49R1-R65) [[2]](diffhunk://#diff-98fec6f1664a2e2e193d2215cc5698068f50ba3d6ebfba5fe8abf0394ddb1d2cR1-R65) [[3]](diffhunk://#diff-138289b8a442b4240f91ea89541ecf118bc82ab0e57f3ae953c11ffd52254e4fR1-R65) [[4]](diffhunk://#diff-bda6d6619043818f2835cd692cd5ea0f48305ee6768aa9054187c9a47003f0a6R1-R65) [[5]](diffhunk://#diff-d50cd30b509d31b5c61a56329f279aba037b5e99eb121de9a647f83c219d818fR1-R65) [[6]](diffhunk://#diff-ab8306b24dc4dac0c8a835548a5ca04887655ccd696e3ea075ed399008b51253R1-R65)
* Added an overview page (`index.md`) explaining how CVSS v4 can be assessed using SSVC, how the equivalence sets are modeled, and how qualitative severity ratings are derived.
* Added a documentation page for the CVSS v4 Qualitative Severity Rating, including the decision model and mapping from equivalence sets to qualitative ratings.

Navigation updates:

* Updated `mkdocs.yml` to add a new "CVSS v4 Analyst Models" section in the navigation, linking to the new documentation pages for each equivalence set and the qualitative severity rating.

Terminology corrections:

* Fixed terminology in code and test comments from "Equivalency Set" to "Equivalence Set" for consistency with CVSS v4 documentation. (`qualitative_severity.py`, `_v4expected.py`) [[1]](diffhunk://#diff-a8389a585e23f8bd89a2c7c4305e79fe95e50b4d5047f2aad0eb0ba418212282L3-R3) [[2]](diffhunk://#diff-d43ece1ad7b9858f3a351ec4276a276b20ddf4b767e5e1c6c6093636cae016d3L3-R3)
